### PR TITLE
Add docs and other tweaks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,19 +28,20 @@ jobs:
       - run: "./run.sh setup"
       - run: "./run.sh lint"
 
-  # tests:
-  #   runs-on: "ubuntu-24.04"
-  #   strategy:
-  #     matrix:
-  #       python-version:
-  #         - "3.9"
-  #         - "3.10"
-  #         - "3.11"
-  #         - "3.12"
-  #         - "3.13"
-  #   steps:
-  #     - uses: "actions/checkout@v4"
-  #     - uses: "astral-sh/setup-uv@v5"
-  #       with:
-  #         version: "0.6.6"
-  #         python-version: "${{ matrix.python-version }}"
+  tests:
+    runs-on: "ubuntu-24.04"
+    strategy:
+      matrix:
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "astral-sh/setup-uv@v5"
+        with:
+          version: "0.6.6"
+          python-version: "${{ matrix.python-version }}"
+      - run: "./run.sh test-build"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,7 @@ jobs:
   tests:
     runs-on: "ubuntu-24.04"
     needs:
+      - "shellcheck"
       - "lint"
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,8 @@ jobs:
 
   tests:
     runs-on: "ubuntu-24.04"
+    needs:
+      - "lint"
     strategy:
       matrix:
         python-version:
@@ -44,4 +46,5 @@ jobs:
         with:
           version: "0.6.6"
           python-version: "${{ matrix.python-version }}"
+      - run: "./run.sh setup"
       - run: "./run.sh test-build"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,5 +22,4 @@ build:
       - "uv run ansible-galaxy collection install -r docs/requirements.yaml"
     build:
       html:
-        - "NO_COLOR=1 uv run mkdocs build --site-dir $READTHEDOCS_OUTPUT/html"
-        # TODO: enable fail on warnings: mkdocs build --strict
+        - "NO_COLOR=1 uv run mkdocs build --strict --site-dir $READTHEDOCS_OUTPUT/html"

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # MkDocs Ansible Collection
 
-[MkDocs](https://www.mkdocs.org) Plugin that automatically generates documentation pages for Ansible Collections. Check out the showcase over on the project's [documentation page](https://mkdocs-ansible-collection.readthedocs.io/en/latest/showcase/)!
+[MkDocs](https://www.mkdocs.org) Plugin that automatically generates documentation pages for Ansible Collections. Check out the showcase over on the project's [documentation page](https://mkdocs-ansible-collection.readthedocs.io/en/stable/showcase/) and more detailed [User](https://mkdocs-ansible-collection.readthedocs.io/en/stable/user/) and [Developer](https://mkdocs-ansible-collection.readthedocs.io/en/stable/dev/) guides!
 
 ## Quick Start
 
-1. Add the `mkdocs-ansible-collection` package to your project's docs dependencies. It will also install `ansible-core` to manage collections and get the required metadata.
+1. Add the `mkdocs-ansible-collection` Python package to your project's docs dependencies. It will also install `ansible-core` to manage collections and get the required metadata.
 
     ```
     pip install mkdocs-ansible-collection
     ```
 
-2. Install any needed collection(s) using `ansible-galaxy collection install <names>` or point ansible at the correct collection path.
+2. Install any needed collection(s) using `ansible-galaxy collection install example.collection` or point ansible at the correct collection path.
 
 3. Enable the plugin in your project's `mkdocs.yaml` file:
 
@@ -18,7 +18,7 @@
     plugins:
       - "ansible-collection":
           collections:
-            - fqcn: "collection.example"
+            - fqcn: "example.collection"
     ```
 
 4. Add an anchor page to the `nav` section of your project's `mkdocs.yaml` file:
@@ -28,34 +28,13 @@
       # The anchor is named after the Collection FQCN and it tells mkdocs where
       # to generate the documentation tree. The following examples show all of
       # the currently supported combinations:
-      - "Ansible Builtins": "ansible.builtin"
-      - "Collection Showcase":
-        - "showcase/index.md"
-        - "ansible.posix"
-      - "networktocode.nautobot"
+      - "Example Collection": "example.collection" # With an explicit page name
+      - "Nested Under Another Page":
+        - "example.collection" # Without a custom page name
     ```
 
-For more details, check out the detailed [User Guide](user_guide.md) and look at the documentation example of [this project's docs](https://github.com/cmsirbu/mkdocs-ansible-collection) themselves which showcase how to build and host collection docs on the awesome [Read the Docs](https://about.readthedocs.com/) service!
-
-### Requirements and Compatibility
-
-To generate the pages dynamically at build time, the plugin uses metadata exported by the `ansible-doc` tool, which must be installed together with the collections you want to generate documentation for in your environment.
-
-The plugin has been built for `mkdocs >= 1.6.0` and has only been tested with the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme.
-
-## Developing
-
-To set up the development environment, make sure you have [uv](https://docs.astral.sh/uv/getting-started/installation/) installed, then run the following commands in the project root:
-
-```
-uv sync
-uv run mkdocs serve
-```
+For more details, check out the [User Guide](https://mkdocs-ansible-collection.readthedocs.io/en/stable/user/) and look at the live example of [this project's docs](https://github.com/cmsirbu/mkdocs-ansible-collection), themselves which showcase how to build and host collection docs on the awesome [Read the Docs](https://about.readthedocs.com/) service!
 
 ## Contributions
 
-!!! warning Work in Progress
-
-    This plugin is under initial development - you can track progress towards the first fully functional release [here](https://github.com/cmsirbu/mkdocs-ansible-collection/milestone/1).
-
-Contributions of all sorts (bug reports, features, documentation etc.) are welcome! If you're not sure about any of the changes you are proposing, please open a new issue to discuss it first.
+Contributions of all sorts (bug reports, features, documentation etc.) are welcome! Any larger change, please open a new [issue](https://github.com/cmsirbu/mkdocs-ansible-collection/issues) to discuss it first.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
         - "example.collection" # Without a custom page name
     ```
 
-For more details, check out the [User Guide](https://mkdocs-ansible-collection.readthedocs.io/en/stable/user/) and look at the live example of [this project's docs](https://github.com/cmsirbu/mkdocs-ansible-collection), themselves which showcase how to build and host collection docs on the awesome [Read the Docs](https://about.readthedocs.com/) service!
+For more details, check out the [User Guide](https://mkdocs-ansible-collection.readthedocs.io/en/stable/user/) and look at the live example of [this project's docs](https://github.com/cmsirbu/mkdocs-ansible-collection), which showcase how to build and host collection docs on the awesome [Read the Docs](https://about.readthedocs.com/) service!
 
 ## Contributions
 

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -1,0 +1,40 @@
+---
+hide:
+  - navigation
+---
+
+# Developer Guide
+
+To set up the development environment, first make sure you have [uv](https://docs.astral.sh/uv/getting-started/installation/) installed. This project is set up to use the plugin itself to generate its own docs.
+
+Now run the following commands in the project root:
+
+```
+# This installs the needed dependencies in a virtual environment managed by uv
+# and the ansible collections defined in the docs/requirements.yaml file.
+./run.sh setup
+
+# Build and serve docs
+./run.sh serve
+```
+
+MkDocs will serve docs on localhost and automatically rebuild on documentation changes. The browser page should also automatically reload on successful rebuild.
+
+!!! warning
+    MkDocs will NOT detect python code changes in the plugin, you will need to stop the server (press Ctrl-C) and start it again with `./run.sh serve`.
+
+## View Debug Output
+
+This plugin logs a lot of useful information at the `DEBUG` level, which you can get by adding the `-v` parameter to `mkdocs` - be warned this generates a LOT of output!
+
+```
+./run.sh serve -v
+```
+
+## Debug Ansible Metadata
+
+To extract a JSON metadata file from an ansible collection, use the following command:
+
+```
+uv run ansible-doc --metadata-dump --no-fail-on-errors networktocode.nautobot > ansible-doc-nautobot.json
+```

--- a/docs/showcase/index.md
+++ b/docs/showcase/index.md
@@ -7,12 +7,12 @@ nav:
   # The anchor is named after the Collection FQCN and it tells mkdocs where
   # to generate the documentation tree. The following examples show all of
   # the currently supported combinations:
-  - "Ansible Builtins": "ansible.builtin"
   - "Collection Showcase":
     - "showcase/index.md"
     - "ansible.posix"
     - "ansible.netcommon"
     - "ansible.utils"
     - "Arista EOS": "arista.eos"
+  - "Ansible Builtins": "ansible.builtin"
   - "networktocode.nautobot"
 ```

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -1,0 +1,92 @@
+---
+hide:
+  - navigation
+---
+
+# User Guide
+
+This MkDocs plugin generates documentation pages dynamically from Ansible Collection metadata.
+
+## Requirements and Compatibility
+
+The dependencies and minimum supported versions are as follows:
+
+- [Python](https://www.python.org/downloads/) `3.9`
+- [MkDocs](https://www.mkdocs.org) `1.6.0`
+- [Ansible Core](https://docs.ansible.com/ansible-core/devel/index.html) `2.15`
+
+While the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme is not a direct requirement, the plugin has only been developed and tested with it.
+
+## Getting Started
+
+Add the `mkdocs-ansible-collection` Python package to your project's docs dependencies using your project management tool of choice. It will also install `ansible-core` to manage collections and get the required metadata.
+
+```
+pip install mkdocs-ansible-collection
+```
+
+Install any needed collection(s) using `ansible-galaxy collection install example.collection` or `ansible-galaxy collection install -r requirements.yaml` or point ansible at the correct collection path via `ansible.cfg`.
+
+Each Ansible Collection FQCN must be added to the Plugin Configuration and have an anchor defined in the `nav` section of your docs! See both sections below for details.
+
+### Plugin Configuration
+
+Add the plugin to your project's `mkdocs.yaml` file and list all the Ansible Collections that you want documentation generated for:
+
+```yaml
+plugins:
+  - "ansible-collection":
+      collections:
+        - fqcn: "ansible.builtin"
+        - fqcn: "arista.eos"
+        - fqcn: "networktocode.nautobot"
+        - fqcn: "ansible.netcommon"
+```
+
+### Anchor Pages
+
+Add one anchor to the `nav` section of your project's `mkdocs.yaml` file for each collection defined in the plugin configuration. The anchor is named after the Collection FQCN and it tells mkdocs where to generate the documentation tree.
+
+There are several combinations for how the resulting page is named and displayed in the documentation navigation:
+
+- The anchor can be as simple as just the collection name, for example `"arista.eos"` and the page name will default to exactly this collection name.
+- The page name can also be customized to anything you'd like, for example `"My Cool Collection": "example.collection"`.
+- The anchor can be nested, with or without the custom page name, under any section or page in your documentation tree.
+
+```yaml
+nav:
+  - "Collection Showcase":
+    - "showcase/index.md"
+    - "ansible.posix"
+    - "ansible.netcommon"
+    - "ansible.utils"
+    - "Arista EOS": "arista.eos"
+  - "Ansible Builtins": "ansible.builtin"
+  - "networktocode.nautobot"
+```
+
+## Live Example
+
+This project's documentation site serves as a live example on how to set up documentation for a project using this plugin! Feel free to use it as a [template](https://github.com/cmsirbu/mkdocs-ansible-collection) which also includes the necessary configuration to build and host the documentation on the awesome [Read the Docs](https://about.readthedocs.com/) service!
+
+## Ansible Plugin Support
+
+| Plugin Type | Support |
+|-------------|---------|
+| become      | :white_check_mark:       |
+| cache       | :white_check_mark:       |
+| callback    | :white_check_mark:       |
+| connection  | :white_check_mark:       |
+| filter      | :white_check_mark:       |
+| inventory   | :white_check_mark:       |
+| keyword     | :x:       |
+| lookup      | :white_check_mark:       |
+| module      | :white_check_mark:       |
+| shell       | :white_check_mark:       |
+| strategy    | :white_check_mark:       |
+| test        | :white_check_mark:       |
+| vars        | :white_check_mark:       |
+| cliconf     | :white_check_mark:       |
+| httpapi     | :white_check_mark:       |
+| netconf     | :white_check_mark:       |
+| role        | :x:       |

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,3 +1,0 @@
-# User Guide
-
-🚧 Work in Progress 🚧

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -50,12 +50,16 @@ plugins:
         - fqcn: "ansible.netcommon"
         - fqcn: "ansible.utils"
         - fqcn: "arista.eos"
-          plugin_types:  # NYI
+          plugin_types:  # Not Yet Implemented
             - "inventory"
             - "module"
 
 
 markdown_extensions:
+  - "attr_list"
+  - "pymdownx.emoji":
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - "admonition"
   - "toc":
       permalink: true
@@ -71,18 +75,20 @@ markdown_extensions:
           class: "mermaid"
           format: !!python/name:pymdownx.superfences.fence_code_format
   - "footnotes"
+  - "tables"
 
 watch:
   - "README.md"
 
 nav: # yamllint disable rule:indentation
   - "index.md"
-  - "User Guide": "user_guide.md"
-  - "Ansible Builtins": "ansible.builtin"
+  - "User Guide": "user/index.md"
+  - "Developer Guide": "dev/index.md"
   - "Collection Showcase":
     - "showcase/index.md"
     - "ansible.posix"
     - "ansible.netcommon"
     - "ansible.utils"
     - "Arista EOS": "arista.eos"
+  - "Ansible Builtins": "ansible.builtin"
   - "networktocode.nautobot"

--- a/run.sh
+++ b/run.sh
@@ -14,8 +14,10 @@ function _uvr {
 # -----------------------------------------------------------------------------
 
 function setup {
-    echo "---------- Installing python environment via uv."
+    echo "---------- Installing python environment via uv"
     _uvr uv sync
+    echo "---------- Installing ansible collections from docs/requirements.yaml"
+    _uvr uv run ansible-galaxy collection install -r docs/requirements.yaml
 }
 
 function lint {
@@ -34,8 +36,17 @@ function autofix {
     _uvr ruff format mkdocs_ansible_collection
 }
 
+function serve {
+    echo "---------- BUILDING AND SERVING DOCS"
+    _uvr mkdocs serve "$@"
+}
+
+function test-build {
+    echo "---------- BUILDING DOCS"
+    _uvr mkdocs build --strict
+}
+
 # TODO: function test
-# TODO: function docs
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
- Added User and Developer Guides to project docs and simplified README.
- Enabled CI testing the mkdocs build on all supported Python versions.
- Enabled strict mode in RTD builds.