### PR TITLE
Improve plugin parameters table

### DIFF
--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -3,3 +3,6 @@ collections:
   - name: "ansible.posix"
   - name: "networktocode.nautobot"
   - name: "arista.eos"
+  # - name: "arista.avd"
+  - name: "opsmill.infrahub"
+  - name: "nokia.srlinux"

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -2,14 +2,19 @@
 site_name: "MkDocs Ansible Collection"
 site_url: "https://mkdocs-ansible-collection.readthedocs.io/en/latest/"
 repo_url: "https://github.com/cmsirbu/mkdocs-ansible-collection"
+edit_uri: "edit/main/docs/"
 
 theme:
   name: "material"
   navigation_depth: 4
+  icon:
+    edit: "material/pencil"
+    view: "material/eye"
   features:
     - "content.action.edit"
     - "content.action.view"
     - "content.code.copy"
+    - "content.tooltips"
     - "navigation.footer"
     - "navigation.indexes"
     - "navigation.tabs"
@@ -50,10 +55,9 @@ plugins:
         - fqcn: "ansible.netcommon"
         - fqcn: "ansible.utils"
         - fqcn: "arista.eos"
-          plugin_types:  # Not Yet Implemented
-            - "inventory"
-            - "module"
-
+        # - fqcn: "arista.avd"
+        - fqcn: "opsmill.infrahub"
+        - fqcn: "nokia.srlinux"
 
 markdown_extensions:
   - "attr_list"
@@ -90,5 +94,8 @@ nav: # yamllint disable rule:indentation
     - "ansible.netcommon"
     - "ansible.utils"
     - "Arista EOS": "arista.eos"
+    # - "Arista AVD": "arista.avd"
+    - "OpsMill Infrahub": "opsmill.infrahub"
+    - "Nokia SRLinux": "nokia.srlinux"
   - "Ansible Builtins": "ansible.builtin"
   - "networktocode.nautobot"

--- a/mkdocs_ansible_collection/templates/plugin.md.jinja
+++ b/mkdocs_ansible_collection/templates/plugin.md.jinja
@@ -47,6 +47,14 @@ The following Python packages are needed on the host that executes this module:
 {{- param_values['description'] if param_values['description'] is string else param_values['description'] | join('<br>') }}
   {%- for env_var in param_values['env'] %}<br>Env: {{ env_var['name'] }}{% endfor %}
   {%- if param_values['version_added'] is defined %}<br>{{ 'Version Added: ' ~ param_values['version_added'] }}{% endif %} |
+{% if param_values['suboptions'] %}
+  {% for subopt_name, subopt_values in param_values['suboptions'].items() %}
+  | {{ param_name }}.**{{ subopt_name }}** |
+  {%- if subopt_values['default'] %}**Default**: {{ subopt_values['default'] }}<br>{% endif %}
+    {%- if subopt_values['choices'] %}**Choices**: {{ subopt_values['choices'] | join(', ') }}{% endif %} |
+  {{- subopt_values['description'] if subopt_values['description'] is string else subopt_values['description'] | join('<br>') }} |
+  {% endfor %}
+{% endif %}
 {% endfor %}
 {% endif %}
 

--- a/mkdocs_ansible_collection/templates/plugin.md.jinja
+++ b/mkdocs_ansible_collection/templates/plugin.md.jinja
@@ -34,29 +34,53 @@ The following Python packages are needed on the host that executes this module:
 {% if pd['options'] is defined and pd['options'] is not none %}
 ## Parameters
 
-| Parameter | Defaults / Choices | Comments |
-| --------- | ------------------ | -------- |
+<table>
+  <thead>
+  <tr>
+  <th>Parameter</th>
+  <th>Defaults / Choices</th>
+  <th>Comments</th>
+  </tr>
+  </thead>
+<tbody>
 {% for param_name, param_values in pd['options'].items() %}
-| **{{ param_name }}**
+<tr>
+<td><strong>{{ param_name }}</strong>
   {%- if param_values['type'] %}<br>{{ param_values['type'] }}
     {%- if param_values['elements'] %} / elements={{ param_values['elements'] }}{% endif %}
   {%- endif %}
-  {%- if param_values['required'] %}<br>*required*{% endif %} |
-{%- if param_values['default'] %}**Default**: {{ param_values['default'] }}<br>{% endif %}
-  {%- if param_values['choices'] %}**Choices**: {{ param_values['choices'] | join(', ') }}{% endif %} |
+  {%- if param_values['required'] %}<br><em>required</em>{% endif %}
+</td>
+<td>
+{%- if param_values['default'] %}<strong>Default</strong>: {{ param_values['default'] }}<br>{% endif %}
+  {%- if param_values['choices'] %}<strong>Choices</strong>: {{ param_values['choices'] | join(', ') }}{% endif %}
+</td>
+<td>
 {{- param_values['description'] if param_values['description'] is string else param_values['description'] | join('<br>') }}
   {%- for env_var in param_values['env'] %}<br>Env: {{ env_var['name'] }}{% endfor %}
-  {%- if param_values['version_added'] is defined %}<br>{{ 'Version Added: ' ~ param_values['version_added'] }}{% endif %} |
+  {%- if param_values['version_added'] is defined %}<br>{{ 'Version Added: ' ~ param_values['version_added'] }}{% endif %}
+</td>
+</tr>
 {% if param_values['suboptions'] %}
   {% for subopt_name, subopt_values in param_values['suboptions'].items() %}
-  | {{ param_name }}.**{{ subopt_name }}** |
-  {%- if subopt_values['default'] %}**Default**: {{ subopt_values['default'] }}<br>{% endif %}
-    {%- if subopt_values['choices'] %}**Choices**: {{ subopt_values['choices'] | join(', ') }}{% endif %} |
-  {{- subopt_values['description'] if subopt_values['description'] is string else subopt_values['description'] | join('<br>') }} |
+  <tr>
+    <td>
+    {{ param_name }}.<strong>{{ subopt_name }}</strong>
+    </td>
+    <td>
+    {%- if subopt_values['default'] %}<strong>Default</strong>: {{ subopt_values['default'] }}<br>{% endif %}
+    {%- if subopt_values['choices'] %}<strong>Choices</strong>: {{ subopt_values['choices'] | join(', ') }}{% endif %}
+    </td>
+    <td>
+    {{- subopt_values['description'] if subopt_values['description'] is string else subopt_values['description'] | join('<br>') }}
+    </td>
+  </tr>
   {% endfor %}
 {% endif %}
 {% endfor %}
 {% endif %}
+</tbody>
+</table>
 
 {% if pd['notes'] is defined and pd['notes'] is not none %}
 ## Notes

--- a/mkdocs_ansible_collection/templates/plugin.md.jinja
+++ b/mkdocs_ansible_collection/templates/plugin.md.jinja
@@ -34,7 +34,7 @@ The following Python packages are needed on the host that executes this module:
 {% if pd['options'] is defined and pd['options'] is not none %}
 ## Parameters
 
-| Parameter | Choices / Defaults | Comments |
+| Parameter | Defaults / Choices | Comments |
 | --------- | ------------------ | -------- |
 {% for param_name, param_values in pd['options'].items() %}
 | **{{ param_name }}**
@@ -42,10 +42,10 @@ The following Python packages are needed on the host that executes this module:
     {%- if param_values['elements'] %} / elements={{ param_values['elements'] }}{% endif %}
   {%- endif %}
   {%- if param_values['required'] %}<br>*required*{% endif %} |
-{{- 'Choices' }} <br>|
-
+{%- if param_values['default'] %}**Default**: {{ param_values['default'] }}<br>{% endif %}
+  {%- if param_values['choices'] %}**Choices**: {{ param_values['choices'] | join(', ') }}{% endif %} |
 {{- param_values['description'] if param_values['description'] is string else param_values['description'] | join('<br>') }}
-  {%- for env_var in param_values['env'] %}<br>env: {{ env_var['name'] }}{% endfor %}
+  {%- for env_var in param_values['env'] %}<br>Env: {{ env_var['name'] }}{% endfor %}
   {%- if param_values['version_added'] is defined %}<br>{{ 'Version Added: ' ~ param_values['version_added'] }}{% endif %} |
 {% endfor %}
 {% endif %}

--- a/mkdocs_ansible_collection/templates/plugin.md.jinja
+++ b/mkdocs_ansible_collection/templates/plugin.md.jinja
@@ -34,11 +34,16 @@ The following Python packages are needed on the host that executes this module:
 {% if pd['options'] is defined and pd['options'] is not none %}
 ## Parameters
 
-| Parameter | Data Type | Environment Variable | Comments |
-| --------- | --------- | -------------------- | -------- |
+| Parameter | Choices / Defaults | Configuration | Comments |
+| --------- | ------------------ | ------------- | -------- |
 {% for param_name, param_values in pd['options'].items() %}
-| **{{ param_name }}**{% if param_values['required'] %}<br>*required*{% endif %} |
-{{- param_values['type'] }} | {% for env_var in param_values['env'] %} {{ env_var['name'] }} {% endfor %} |
+| **{{ param_name }}**
+  {%- if param_values['type'] %}<br>{{ param_values['type'] }}
+    {%- if param_values['elements'] %} / elements={{ param_values['elements'] }}{% endif %}
+  {%- endif %}
+  {%- if param_values['required'] %}<br>*required*{% endif %} |
+{{- 'Choices' }} <br>|
+{%- for env_var in param_values['env'] %} {{ env_var['name'] }} {% endfor %} |
 {{- param_values['description'] if param_values['description'] is string else param_values['description'] | join(' ') }}
 {%- if param_values['version_added'] is defined %}<br>{{ 'Version Added: ' ~ param_values['version_added'] }}{% endif %} |
 {% endfor %}

--- a/mkdocs_ansible_collection/templates/plugin.md.jinja
+++ b/mkdocs_ansible_collection/templates/plugin.md.jinja
@@ -34,8 +34,8 @@ The following Python packages are needed on the host that executes this module:
 {% if pd['options'] is defined and pd['options'] is not none %}
 ## Parameters
 
-| Parameter | Choices / Defaults | Configuration | Comments |
-| --------- | ------------------ | ------------- | -------- |
+| Parameter | Choices / Defaults | Comments |
+| --------- | ------------------ | -------- |
 {% for param_name, param_values in pd['options'].items() %}
 | **{{ param_name }}**
   {%- if param_values['type'] %}<br>{{ param_values['type'] }}
@@ -43,9 +43,10 @@ The following Python packages are needed on the host that executes this module:
   {%- endif %}
   {%- if param_values['required'] %}<br>*required*{% endif %} |
 {{- 'Choices' }} <br>|
-{%- for env_var in param_values['env'] %} {{ env_var['name'] }} {% endfor %} |
-{{- param_values['description'] if param_values['description'] is string else param_values['description'] | join(' ') }}
-{%- if param_values['version_added'] is defined %}<br>{{ 'Version Added: ' ~ param_values['version_added'] }}{% endif %} |
+
+{{- param_values['description'] if param_values['description'] is string else param_values['description'] | join('<br>') }}
+  {%- for env_var in param_values['env'] %}<br>env: {{ env_var['name'] }}{% endfor %}
+  {%- if param_values['version_added'] is defined %}<br>{{ 'Version Added: ' ~ param_values['version_added'] }}{% endif %} |
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
Fixes #18 

Added data type to the parameter column.
Moved env vars to the comments column.
Added defaults and choices column to the parameters table.
Added suboptions when a parameter has dictionary sub-values.
Changed parameters table to inline HTML since Markdown tables break with any errant newlines.
Added opsmill.infrahub and nokia.srlinux collections to showcase.
Fixed page view/edit github links.